### PR TITLE
Improve 'Show in a map' feature

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,8 @@ module.exports = function (grunt) {
                     layout: function (type, component, source) {
                         return type;
                     },
-                    targetDir: './build/lib/lib'
+                    targetDir: './build/lib/lib',
+                    copy: true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "description": "This package.json file is only used for installing npm dependencies. But this is not an installable node package, but a WireCloud operator. Take a look into src/config.xml for more details about this widget",
   "devDependencies": {
-    "grunt": "^0.4.5",
-    "grunt-bower-task": "^0.4.0",
-    "grunt-contrib-clean": "~0.6.0",
-    "grunt-contrib-compress": "^0.11.0",
-    "grunt-contrib-copy": "^0.8.0",
-    "grunt-contrib-jasmine": "^1.0.0",
-    "grunt-strip-code": "^0.1.2",
-    "grunt-template-jasmine-istanbul": "^0.3.0",
+    "grunt": "^1.0.4",
+    "grunt-bower-task": "^0.5.0",
+    "grunt-contrib-clean": "~2.0.0",
+    "grunt-contrib-compress": "^1.6.0",
+    "grunt-contrib-copy": "^1.0.0",
+    "grunt-contrib-jasmine": "^2.1.0",
+    "grunt-strip-code": "^1.0.6",
+    "grunt-template-jasmine-istanbul": "^0.5.0",
     "grunt-text-replace": "~0.4.0",
-    "grunt-wirecloud": "^0.9.0",
-    "gruntify-eslint": "^3.1.0",
+    "grunt-wirecloud": "^0.9.7",
+    "gruntify-eslint": "^5.0.0",
     "mock-applicationmashup": "^0.1.3",
-    "wirecloud-config-parser": "^0.2.0"
+    "wirecloud-config-parser": "^0.2.2"
   },
   "private": true
 }

--- a/src/config.xml
+++ b/src/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='UTF-8'?>
-<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-type-browser" version="1.0.4">
+<widget xmlns="http://wirecloud.conwet.fi.upm.es/ns/macdescription/1" vendor="CoNWeT" name="ngsi-type-browser" version="1.0.5a1">
     <details>
         <title>NGSI Type browser</title>
         <homepage>https://github.com/wirecloud-fiware/ngsi-type-browser-widget</homepage>
@@ -21,13 +21,67 @@
     </requirements>
 
     <preferences>
-        <preference name="ngsi_server" type="text" label="NGSI server URL" description="URL of the Orion Context Broker to use for retrieving entity information" default="http://orion.lab.fiware.org:1026/"/>
-        <preference name="use_user_fiware_token" type="boolean" label="Use the FIWARE credentials of the user" description="Use the FIWARE credentials of the user logged into WireCloud. Take into account this option cannot be enabled if you want to use this widget in a public workspace as anonoymous users doesn't have a valid FIWARE auth token" default="true"/>
-        <preference name="use_owner_credentials" type="boolean" label="Use the FIWARE credentials of the workspace owner" description="Use the FIWARE credentials of the owner of the workspace. This preference takes preference over &quot;Use the FIWARE credentials of the user&quot;. This feature is available on WireCloud 0.7.0+ in a experimental basis, future versions of WireCloud can change the way to use it making this option not funcional and requiring you to upgrade this operator" default="false"/>
-        <preference name="ngsi_tenant" type="text" label="NGSI tenant/service" description="Tenant/service to use when connecting to the context broker. Must be a string of alphanumeric characters (lowercase) and the &quot;_&quot; symbol. Maximum length is 50 characters. If empty, the default tenant will be used" default=""/>
-        <preference name="ngsi_service_path" type="text" label="NGSI scope" description="Scope/path to use when connecting to the context broker. Must be a string of alphanumeric characters (lowercase) and the &quot;_&quot; symbol separated by &quot;/&quot; slashes. Maximum length is 50 characters. If empty, the default service path will be used: /" default="/"/>
-        <preference name="allow_map" type="boolean" label="Display a Show in a map button" description="Allow users to display entities in a map" default="true"/>
-        <preference name="allow_use" type="boolean" label="Run button" description="Display a use button" default="true"/>
+        <preference
+            name="ngsi_server"
+            type="text"
+            label="NGSI server URL"
+            description="URL of the Orion Context Broker to use for retrieving entity information"
+            default="http://orion.lab.fiware.org:1026/"/>
+        <preference
+            name="ngsi_proxy"
+            type="text"
+            label="NGSI proxy URL"
+            description="URL of the Orion Context Broker proxy to use for receiving notifications about changes"
+            default="https://ngsiproxy.lab.fiware.org" />
+        <preference
+            name="use_user_fiware_token"
+            type="boolean" label="Use the FIWARE credentials of the user"
+            description="Use the FIWARE credentials of the user logged into WireCloud. Take into account this option cannot be enabled if you want to use this widget in a public workspace as anonoymous users doesn't have a valid FIWARE auth token"
+            default="true"/>
+        <preference
+            name="use_owner_credentials"
+            type="boolean"
+            label="Use the FIWARE credentials of the workspace owner"
+            description="Use the FIWARE credentials of the owner of the workspace. This preference takes preference over &quot;Use the FIWARE credentials of the user&quot;. This feature is available on WireCloud 0.7.0+ in a experimental basis, future versions of WireCloud can change the way to use it making this option not funcional and requiring you to upgrade this operator"
+            default="false"/>
+        <preference
+            name="ngsi_tenant"
+            type="text"
+            label="NGSI tenant/service"
+            description="Tenant/service to use when connecting to the context broker. Must be a string of alphanumeric characters (lowercase) and the &quot;_&quot; symbol. Maximum length is 50 characters. If empty, the default tenant will be used"
+            default=""/>
+        <preference name="ngsi_service_path"
+            type="text"
+            label="NGSI scope"
+            description="Scope/path to use when connecting to the context broker. Must be a string of alphanumeric characters (lowercase) and the &quot;_&quot; symbol separated by &quot;/&quot; slashes. Maximum length is 50 characters. If empty, the default service path will be used: /"
+            default="/"/>
+        <preference name="allow_map"
+            type="boolean"
+            label="Display a Show in a map button"
+            description="Allow users to display entities in a map"
+            default="true"/>
+        <preference
+            name="allow_use"
+            type="boolean"
+            label="Run button"
+            description="Display a use button"
+            default="true"/>
+        <preference
+            name="ngsi_souce"
+            type="text"
+            label="NGSI source"
+            description="NGSI source widget"
+            default="CoNWeT/ngsi-source/4.0.0"/>
+        <preference name="entity2poi"
+            type="text"
+            label="NGSI entity to poi"
+            description="NGSI entity to poi operator"
+            default="CoNWeT/ngsientity2poi/3.2.0"/>
+        <preference name="map_viewer"
+            type="text"
+            label="Map viewer"
+            description="Map viewer widget using OpenLayers"
+            default="CoNWeT/ol3-map/1.1.3"/>
     </preferences>
 
     <wiring>

--- a/src/doc/changelog.md
+++ b/src/doc/changelog.md
@@ -1,3 +1,8 @@
+## v1.0.5 (2019-XX-XX)
+
+- Improve 'Show in a map' feature
+
+
 ## v1.0.4 (2018-06-06)
 
 - Upgrade to use FontAwesome 4

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -155,7 +155,7 @@
                         var attr_low = entry.attributes.map(function (attr) {return attr.toLowerCase();});
                         button = new StyledElements.Button({'class': 'btn-success', 'iconClass': 'fa fa-map fa-fw', 'title': 'Show in a map'});
                         var position_attrs = [];
-                        ['position', 'current_position'].some(function (attr_name) {
+                        ['location', 'position', 'current_position'].some(function (attr_name) {
                             if (attr_low.indexOf(attr_name) !== -1) {
                                 position_attrs.push(attr_name);
                                 return true;
@@ -164,19 +164,24 @@
                         });
                         button.enabled = position_attrs.length > 0;
                         button.addEventListener("click", function () {
-                            var source = MashupPlatform.mashup.addOperator('CoNWeT/ngsi-source/3.0.7', {
+                            var source = MashupPlatform.mashup.addOperator(MashupPlatform.prefs.get('ngsi_souce').trim(), {
                                 "preferences": {
-                                    "ngsi_server": {"value": MashupPlatform.prefs.get("ngsi_server")},
+                                    "ngsi_server": {"value": MashupPlatform.prefs.get("ngsi_server").trim()},
+                                    "ngsi_proxy": {"value": MashupPlatform.prefs.get("ngsi_proxy").trim()},
+                                    "use_user_fiware_token": {"value": MashupPlatform.prefs.get("use_user_fiware_token")},
+                                    "use_owner_credentials": {"value": MashupPlatform.prefs.get("use_owner_credentials")},
+                                    "ngsi_tenant": {"value": MashupPlatform.prefs.get('ngsi_tenant').trim()},
+                                    "ngsi_service_path": {"value": MashupPlatform.prefs.get('ngsi_service_path').trim()},
                                     "ngsi_entities": {"value": entry.name},
                                     "ngsi_update_attributes": {"value": position_attrs.join(', ')}
-                                }
+                                },
                             });
-                            var adapter = MashupPlatform.mashup.addOperator('CoNWeT/ngsientity2poi/3.0.3', {
+                            var adapter = MashupPlatform.mashup.addOperator(MashupPlatform.prefs.get('entity2poi').trim(), {
                                 "preferences": {
                                     "coordinates_attr": {"value": position_attrs.join(', ')}
                                 }
                             });
-                            var map = MashupPlatform.mashup.addWidget('CoNWeT/map-viewer/2.5.8', {
+                            var map = MashupPlatform.mashup.addWidget(MashupPlatform.prefs.get('map_viewer').trim(), {
                                 "refposition": button.getBoundingClientRect()
                             });
 


### PR DESCRIPTION
Hi @aarranz,

This PR improves the 'Show in a map' feature of the NGSI type browser widget. It supoorts the `location` attribute as a position information and allows to configure a version of the widgets (ngsi-source, ngsi-entity2poi and ol3-map).

![settings](https://user-images.githubusercontent.com/31051904/69473339-c6fff300-0df6-11ea-9da5-3bfb85b6079e.png)

- Live demo
[https://mashup.lab.fisuda.jp/letsfiware/ngsi-type-browser#view=workspace&tab=tab](https://mashup.lab.fisuda.jp/letsfiware/ngsi-type-browser#view=workspace&tab=tab)

![ngsi-type-browser](https://user-images.githubusercontent.com/31051904/69473060-56a4a200-0df5-11ea-9bd4-4c0dda4000b0.png)

It would be great if you could review this PR.

Thank you.